### PR TITLE
Implement Polylines per Cell widget

### DIFF
--- a/geest/gui/indicator_widget_factory.py
+++ b/geest/gui/indicator_widget_factory.py
@@ -3,6 +3,7 @@ from .widgets.base_indicator_widget import BaseIndicatorWidget
 from .widgets import IndexScoreRadioButton
 from .widgets import DontUseRadioButton
 from .widgets import MultiBufferDistancesWidget
+from .widgets import PolylineWidget
 
 
 class RadioButtonFactory:
@@ -36,6 +37,8 @@ class RadioButtonFactory:
                 return IndexScoreRadioButton(label_text=key, attributes=attributes)
             if key == "Use Multi Buffer Point" and value == 1:
                 return MultiBufferDistancesWidget(label_text=key, attributes=attributes)
+            if key == "Use Polyline per Cell" and value == 1:
+                return PolylineWidget(label_text=key, attributes=attributes)
             else:
                 QgsMessageLog.logMessage(
                     f"Factory did not match any widgets",

--- a/geest/gui/widgets/__init__.py
+++ b/geest/gui/widgets/__init__.py
@@ -2,3 +2,4 @@
 from .indicator_index_score_widget import IndexScoreRadioButton
 from .dont_use_widget import DontUseRadioButton
 from .multi_buffer_distances_widget import MultiBufferDistancesWidget
+from .polyline_widget import PolylineWidget

--- a/geest/gui/widgets/polyline_widget.py
+++ b/geest/gui/widgets/polyline_widget.py
@@ -1,0 +1,164 @@
+from qgis.PyQt.QtWidgets import (
+    QLabel,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QToolButton,
+    QFileDialog,
+)
+from qgis.gui import QgsMapLayerComboBox
+from qgis.core import QgsMessageLog, QgsMapLayerProxyModel, QgsProject, QgsVectorLayer
+from qgis.PyQt.QtCore import QSettings
+import os
+
+from .base_indicator_widget import BaseIndicatorWidget
+
+
+class PolylineWidget(BaseIndicatorWidget):
+    """
+    A widget for selecting a polyline (paths) layer with options for shapefile inputs.
+
+    This widget provides one `QgsMapLayerComboBox` components for selecting polyline layers,
+    as well as `QLineEdit` and `QToolButton` components to allow the user to specify shapefile paths for
+    each layer. The user can choose layers either from the QGIS project or provide external shapefiles.
+
+    Attributes:
+        widget_key (str): The key identifier for this widget.
+        polyline_layer_combo (QgsMapLayerComboBox): A combo box for selecting the polyline layer.
+        polyline_shapefile_line_edit (QLineEdit): Line edit for entering/selecting a polyline layer shapefile.
+    """
+
+    def add_internal_widgets(self) -> None:
+        """
+        Adds the internal widgets required for selecting polyline layers and their corresponding shapefiles.
+        This method is called during the widget initialization and sets up the layout for the UI components.
+        """
+        try:
+            self.main_layout = QVBoxLayout()
+            self.widget_key = "Polyline per Cell"
+
+            # Polyline Layer Section
+            self._add_polyline_layer_widgets()
+
+            # Add the main layout to the widget's layout
+            self.layout.addLayout(self.main_layout)
+
+            # Connect signals to update the data when user changes selections
+            self.polyline_layer_combo.currentIndexChanged.connect(self.update_data)
+            self.polyline_shapefile_line_edit.textChanged.connect(self.update_data)
+
+        except Exception as e:
+            QgsMessageLog.logMessage(f"Error in add_internal_widgets: {e}", "Geest")
+            import traceback
+
+            QgsMessageLog.logMessage(traceback.format_exc(), "Geest")
+
+    def _add_polyline_layer_widgets(self) -> None:
+        """
+        Adds the widgets for selecting the polyline layer, including a `QgsMapLayerComboBox` and shapefile input.
+        """
+        self.polyline_layer_label = QLabel(
+            "Polyline Layer - shapefile will have preference"
+        )
+        self.main_layout.addWidget(self.polyline_layer_label)
+
+        # Polyline Layer ComboBox (Filtered to line layers)
+        self.polyline_layer_combo = QgsMapLayerComboBox()
+        self.polyline_layer_combo.setFilters(QgsMapLayerProxyModel.LineLayer)
+        self.main_layout.addWidget(self.polyline_layer_combo)
+
+        # Restore previously selected polyline layer
+        polyline_layer_id = self.attributes.get(
+            f"{self.widget_key} Polyline Layer ID", None
+        )
+        if polyline_layer_id:
+            polyline_layer = QgsProject.instance().mapLayer(polyline_layer_id)
+            if polyline_layer:
+                self.polyline_layer_combo.setLayer(polyline_layer)
+
+        # Shapefile Input for Polyline Layer
+        self.polyline_shapefile_layout = QHBoxLayout()
+        self.polyline_shapefile_line_edit = QLineEdit()
+        self.polyline_shapefile_button = QToolButton()
+        self.polyline_shapefile_button.setText("...")
+        self.polyline_shapefile_button.clicked.connect(self.select_polyline_shapefile)
+        if self.attributes.get(f"{self.widget_key} Polyline Shapefile", False):
+            self.polyline_shapefile_line_edit.setText(
+                self.attributes[f"{self.widget_key} Polyline Shapefile"]
+            )
+        self.polyline_shapefile_layout.addWidget(self.polyline_shapefile_line_edit)
+        self.polyline_shapefile_layout.addWidget(self.polyline_shapefile_button)
+        self.main_layout.addLayout(self.polyline_shapefile_layout)
+
+    def select_polyline_shapefile(self) -> None:
+        """
+        Opens a file dialog to select a shapefile for the polyline (paths) layer and updates the QLineEdit with the file path.
+        """
+        try:
+            settings = QSettings()
+            last_dir = settings.value("Geest/lastShapefileDir", "")
+
+            file_path, _ = QFileDialog.getOpenFileName(
+                self, "Select Polyline Shapefile", last_dir, "Shapefiles (*.shp)"
+            )
+            if file_path:
+                self.polyline_shapefile_line_edit.setText(file_path)
+                settings.setValue("Geest/lastShapefileDir", os.path.dirname(file_path))
+
+        except Exception as e:
+            QgsMessageLog.logMessage(
+                f"Error selecting polyline shapefile: {e}", "Geest"
+            )
+
+    def get_data(self) -> dict:
+        """
+        Retrieves and returns the current state of the widget, including selected polyline layers or shapefiles.
+
+        Returns:
+            dict: A dictionary containing the current attributes of the polyline layers and/or shapefiles.
+        """
+        if not self.isChecked():
+            return None
+
+        # Collect data for the polyline layer
+        polyline_layer = self.polyline_layer_combo.currentLayer()
+        if polyline_layer:
+            self.attributes[f"{self.widget_key} Polyline Layer Name"] = (
+                polyline_layer.name()
+            )
+            self.attributes[f"{self.widget_key} Polyline Layer Source"] = (
+                polyline_layer.source()
+            )
+            self.attributes[f"{self.widget_key} Polyline Layer Provider Type"] = (
+                polyline_layer.providerType()
+            )
+            self.attributes[f"{self.widget_key} Polyline Layer CRS"] = (
+                polyline_layer.crs().authid()
+            )
+            self.attributes[f"{self.widget_key} Polyline Layer Wkb Type"] = (
+                polyline_layer.wkbType()
+            )
+            self.attributes[f"{self.widget_key} Polyline Layer ID"] = (
+                polyline_layer.id()
+            )
+        self.attributes[f"{self.widget_key} Polyline Shapefile"] = (
+            self.polyline_shapefile_line_edit.text()
+        )
+
+        return self.attributes
+
+    def set_internal_widgets_enabled(self, enabled: bool) -> None:
+        """
+        Enables or disables the internal widgets (polyline layers) based on the state of the radio button.
+
+        Args:
+            enabled (bool): Whether to enable or disable the internal widgets.
+        """
+        try:
+            self.polyline_layer_combo.setEnabled(enabled)
+            self.polyline_shapefile_line_edit.setEnabled(enabled)
+            self.polyline_shapefile_button.setEnabled(enabled)
+        except Exception as e:
+            QgsMessageLog.logMessage(
+                f"Error in set_internal_widgets_enabled: {e}", "Geest"
+            )


### PR DESCRIPTION
Fixes #209

AT -> Location of cycle paths uses polylines:
![image](https://github.com/user-attachments/assets/97d0317a-d983-493e-bdde-89e82cd36151)

AT -> Location of footpaths uses polylines:
![image](https://github.com/user-attachments/assets/0f792796-3df9-45ac-8839-8fc7ea20159b)