### PR TITLE
Wrong reclassification for: Nighttime lights data Fixes

### DIFF
--- a/geest/core/workflows/safety_raster_workflow.py
+++ b/geest/core/workflows/safety_raster_workflow.py
@@ -9,7 +9,6 @@ from qgis.core import (
     QgsProcessingFeedback,
     QgsRasterLayer,
     QgsVectorLayer,
-    QgsRaster,
 )
 import processing  # QGIS processing toolbox
 from .workflow_base import WorkflowBase
@@ -180,10 +179,6 @@ class SafetyRasterWorkflow(WorkflowBase):
                 "Unsupported data type", "Geest", level=Qgis.Warning
             )
             return None, None, None
-
-        QgsMessageLog.logMessage(
-            f"Raster data type: {data_type}", "Geest", level=Qgis.Info
-        )
 
         # Convert QByteArray to a numpy array with the correct dtype
         raster_array = np.frombuffer(byte_array, dtype=dtype).reshape((height, width))

--- a/geest/core/workflows/safety_raster_workflow.py
+++ b/geest/core/workflows/safety_raster_workflow.py
@@ -9,6 +9,7 @@ from qgis.core import (
     QgsProcessingFeedback,
     QgsRasterLayer,
     QgsVectorLayer,
+    QgsRaster,
 )
 import processing  # QGIS processing toolbox
 from .workflow_base import WorkflowBase
@@ -161,15 +162,15 @@ class SafetyRasterWorkflow(WorkflowBase):
         # Determine the correct dtype based on the provider's data type
         data_type = provider.dataType(1)
         dtype = None
-        if data_type == 5:  # Float32
+        if data_type == 6:  # Float32
             dtype = np.float32
         elif data_type == 3:  # Int16
             dtype = np.int16
-        elif data_type == 4:  # UInt16
+        elif data_type == 2:  # UInt16
             dtype = np.uint16
-        elif data_type == 6:  # Int32
+        elif data_type == 5:  # Int32
             dtype = np.int32
-        elif data_type == 7:  # UInt32
+        elif data_type == 4:  # UInt32
             dtype = np.uint32
         elif data_type == 1:  # Byte
             dtype = np.uint8
@@ -180,6 +181,10 @@ class SafetyRasterWorkflow(WorkflowBase):
             )
             return None, None, None
 
+        QgsMessageLog.logMessage(
+            f"Raster data type: {data_type}", "Geest", level=Qgis.Info
+        )
+
         # Convert QByteArray to a numpy array with the correct dtype
         raster_array = np.frombuffer(byte_array, dtype=dtype).reshape((height, width))
 
@@ -189,9 +194,9 @@ class SafetyRasterWorkflow(WorkflowBase):
 
         if valid_data.size > 0:
             # Compute statistics
-            max_value = np.max(valid_data)
-            median = np.median(valid_data)
-            percentile_75 = np.percentile(valid_data, 75)
+            max_value = np.max(valid_data).astype(dtype)
+            median = np.median(valid_data).astype(dtype)
+            percentile_75 = np.percentile(valid_data, 75).astype(dtype)
 
             return max_value, median, percentile_75
         else:


### PR DESCRIPTION
Wrong reclassification for: Nighttime lights data
Fixes #556

With correct Datatype:

Correct values:
![image](https://github.com/user-attachments/assets/0f653200-12d9-4a8e-8c5a-dd742b1968e4)

Values within range:
![image](https://github.com/user-attachments/assets/435f17f7-5ff2-4c6e-b53e-535acf40a0c2)
