### PR TITLE
Show layer on geest tree click

### DIFF
--- a/geest/gui/geest_settings.py
+++ b/geest/gui/geest_settings.py
@@ -65,6 +65,12 @@ class GeestSettings(FORM_CLASS, QgsOptionsPageWidget):
         chunk_size = int(setting(key="chunk_size", default=50))
         self.chunk_size.setValue(chunk_size)
 
+        zero_default = bool(setting(key="default_raster_to_0", default=0))
+        self.default_raster_to_0.setChecked(bool(zero_default))
+
+        show_layer_on_click = setting(key="show_layer_on_click", default=False)
+        self.show_layer_on_click.setChecked(bool(show_layer_on_click))
+
     def apply(self):
         """Process the animation sequence.
 
@@ -88,6 +94,12 @@ class GeestSettings(FORM_CLASS, QgsOptionsPageWidget):
         set_setting(key="ors_key", value=self.ors_key_line_edit.text())
         set_setting(key="ors_request_size", value=self.ors_request_size.value())
         set_setting(key="chunk_size", value=self.chunk_size.value())
+        set_setting(
+            key="default_raster_to_0", value=self.default_raster_to_0.isChecked()
+        )
+        set_setting(
+            key="show_layer_on_click", value=self.show_layer_on_click.isChecked()
+        )
 
 
 class GeestOptionsFactory(QgsOptionsWidgetFactory):

--- a/geest/ui/geest_settings_base.ui
+++ b/geest/ui/geest_settings_base.ui
@@ -14,6 +14,114 @@
    <string>Geest Settings</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
+   <item row="3" column="0">
+    <widget class="QGroupBox" name="groupBox_4">
+     <property name="title">
+      <string>Analysis Options</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="default_raster_to_0">
+        <property name="text">
+         <string>Assign 0 to cells by default (if unchecked will assign nodata by default)</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Advanced Options</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label_thread_pool_size">
+          <property name="text">
+           <string>Concurrent Tasks</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="spin_thread_pool_size"/>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="thread_pool_description">
+        <property name="text">
+         <string>The maximum number of concurrent threads to allow during analysis. Setting to the same number of CPU cores you have would be a good conservative approach.  If you want to produce your analysis faster, you could probably run 4 or more on a decently specced machine.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="margin">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="debug_mode_checkbox">
+        <property name="text">
+         <string>Enable developer mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="debug_mode_description">
+        <property name="text">
+         <string>This is intended for developers to attach to the plugin using a remote debugger so that they can step through the code. Do not enable it if you do not have a remote debugger set up as it will block QGIS startup until a debugger is attached to the process. In addition, debug mode will enable a log tab in the dock. Requires restart after changing.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="margin">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="verbose_mode_checkbox">
+        <property name="text">
+         <string>Verbose logging mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="verbose_mode_description">
+        <property name="text">
+         <string>Adds verbose log message, useful for diagnostics.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="margin">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -95,89 +203,16 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QGroupBox" name="groupBox">
+   <item row="4" column="0">
+    <widget class="QGroupBox" name="groupBox_5">
      <property name="title">
-      <string>Advanced Options</string>
+      <string>User Interface Options</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
+     <layout class="QGridLayout" name="gridLayout_6">
       <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QLabel" name="label_thread_pool_size">
-          <property name="text">
-           <string>Concurrent Tasks</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="spin_thread_pool_size"/>
-        </item>
-       </layout>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="thread_pool_description">
+       <widget class="QCheckBox" name="show_layer_on_click">
         <property name="text">
-         <string>The maximum number of concurrent threads to allow during analysis. Setting to the same number of CPU cores you have would be a good conservative approach.  If you want to produce your analysis faster, you could probably run 4 or more on a decently specced machine.</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="margin">
-         <number>0</number>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="debug_mode_checkbox">
-        <property name="text">
-         <string>Enable developer mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="debug_mode_description">
-        <property name="text">
-         <string>This is intended for developers to attach to the plugin using a remote debugger so that they can step through the code. Do not enable it if you do not have a remote debugger set up as it will block QGIS startup until a debugger is attached to the process. In addition, debug mode will enable a log tab in the dock. Requires restart after changing.</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="margin">
-         <number>0</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="verbose_mode_checkbox">
-        <property name="text">
-         <string>Verbose logging mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="verbose_mode_description">
-        <property name="text">
-         <string>Adds verbose log message, useful for diagnostics.</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="margin">
-         <number>0</number>
+         <string>Show layer when clicking an item in the Geest tree</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Fixes #800

![show-on-click](https://github.com/user-attachments/assets/d74408f9-9af8-42e5-9184-ea5f7e87628c)


This is just a convenience for me to make it faster to verify outputs  - probably we can make it default since it is really quick to flip through outputs like this...